### PR TITLE
Middlewares

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ inherit_gem:
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.5
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false

--- a/lib/polist.rb
+++ b/lib/polist.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "polist/service"
+require "polist/service/middleware"
 require "polist/version"
 
 module Polist

--- a/lib/polist/service.rb
+++ b/lib/polist/service.rb
@@ -20,12 +20,20 @@ module Polist
       include ActiveModel::Validations
     end
 
+    module MiddlewareCaller
+      def call
+        call_middlewares
+        super
+      end
+    end
+
     MiddlewareError = Class.new(StandardError)
 
     attr_accessor :params
 
     def self.inherited(klass)
       klass.const_set(:Failure, Class.new(klass::Failure))
+      klass.prepend MiddlewareCaller
     end
 
     def self.build(*args)
@@ -71,7 +79,6 @@ module Polist
     def call; end
 
     def run
-      call_middlewares
       call
     rescue self.class::Failure => error
       @response = error.response

--- a/lib/polist/service/middleware.rb
+++ b/lib/polist/service/middleware.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Polist::Service::Middleware
+  def initialize(service)
+    @service = service
+  end
+
+  # Should be implemented in subclasses
+  def call; end
+
+  private
+
+  attr_reader :service
+
+  %i[fail! error! success! form form_attributes].each do |service_method|
+    define_method(service_method) do |*args|
+      service.send(service_method, *args)
+    end
+  end
+end

--- a/spec/polist/service/middleware_spec.rb
+++ b/spec/polist/service/middleware_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class FirstMiddleware < Polist::Service::Middleware
+  def call; end
+end
+
+class SecondMiddleware < Polist::Service::Middleware
+  def call; end
+end
+
+class ServiceWithMiddlewares < Polist::Service
+  def call
+    success!(success: true)
+  end
+end
+
+RSpec.describe Polist::Service::Middleware do
+  before { ServiceWithMiddlewares.__clear_middlewares__ }
+
+  context "middlewares do nothing" do
+    before do
+      ServiceWithMiddlewares.register_middleware FirstMiddleware
+      ServiceWithMiddlewares.register_middleware SecondMiddleware
+    end
+
+    specify "middlewares are called when service is ran" do
+      expect_any_instance_of(FirstMiddleware).to receive(:call)
+      expect_any_instance_of(SecondMiddleware).to receive(:call)
+
+      service = ServiceWithMiddlewares.run
+      expect(service.success?).to eq(true)
+      expect(service.failure?).to eq(false)
+      expect(service.response).to eq(success: true)
+    end
+  end
+
+  specify "middlewares can affect the response of the service" do
+    middleware = Class.new(Polist::Service::Middleware) do
+      def call
+        fail!(failed: true)
+      end
+    end
+
+    ServiceWithMiddlewares.register_middleware middleware
+
+    service = ServiceWithMiddlewares.run
+    expect(service.success?).to eq(false)
+    expect(service.failure?).to eq(true)
+    expect(service.response).to eq(failed: true)
+  end
+
+  specify "middlewares delegate methods to service" do
+    middleware = Class.new(Polist::Service::Middleware) do
+      def call
+        form
+        form_attributes
+        success!
+      end
+    end
+
+    ServiceWithMiddlewares.register_middleware middleware
+
+    expect { ServiceWithMiddlewares.run }.not_to raise_error
+  end
+end

--- a/spec/polist/service_spec.rb
+++ b/spec/polist/service_spec.rb
@@ -123,4 +123,25 @@ RSpec.describe Polist::Service do
       expect(service.response).to eq(error: "failure")
     end
   end
+
+  describe ".register_middleware" do
+    let(:first_middleware) { Class.new(Polist::Service::Middleware) }
+    let(:second_middleware) { Class.new(Polist::Service::Middleware) }
+
+    before do
+      BasicService.register_middleware(first_middleware)
+      BasicService.register_middleware(second_middleware)
+    end
+
+    it "stores middlewares in the service class" do
+      expect(BasicService.__polist_middlewares__)
+        .to contain_exactly(first_middleware, second_middleware)
+    end
+
+    it "raises error if middleware is not a subclass of Polist::Service::Middleware" do
+      expect { BasicService.register_middleware(String) }
+        .to raise_error(Polist::Service::MiddlewareError,
+                        "Middleware String should be a subclass of Polist::Service::Middleware")
+    end
+  end
 end


### PR DESCRIPTION
Consider having a common logic that has to be executed in many services inside an application. Let's say we have an authorization process:
```ruby
class UserDependentWebAction < Polist::Service
  def call
    fail!(code: :unauthorized) unless user.admin?
    # ...business logic
  end
  
  private

  def user
    User.find(id: params[:user_id])
  end
end

class AnotherUserDependentWebAction < Polist::Service
  def call
    fail!(code: :unauthorized) unless user.admin?
    # ...business logic
  end

  private

  def user
    User.find(id: params[:user_id])
  end
end
```

Wouldn't it be better to have middlewares?
```ruby
class UserAuthorizationMiddleware < Polist::Service::Middleware
  def call
    fail!(code: :unauthorized) unless user.admin?
  end

  private

  def user
    User.find(id: service.params[:user_id])
  end
end

class UserDependentWebAction < Polist::Service
  register_middleware UserAuthorizationMiddleware

  def call
    # ...business logic
  end
end

class AnotherUserDependentWebAction < Polist::Service
  register_middleware UserAuthorizationMiddleware

  def call
    # ...business logic
  end
end
```

@tycooon what do you think?