### PR TITLE
Fix middlewares not working with inheritance

### DIFF
--- a/lib/polist/service.rb
+++ b/lib/polist/service.rb
@@ -22,7 +22,11 @@ module Polist
 
     module MiddlewareCaller
       def call
-        call_middlewares
+        unless @__polist_middlewares__called
+          call_middlewares
+          @__polist_middlewares__called = true
+        end
+
         super
       end
     end
@@ -33,7 +37,8 @@ module Polist
 
     def self.inherited(klass)
       klass.const_set(:Failure, Class.new(klass::Failure))
-      klass.prepend MiddlewareCaller
+      klass.prepend(MiddlewareCaller)
+      klass.instance_variable_set(:@__polist_middlewares__, @__polist_middlewares__.dup)
     end
 
     def self.build(*args)

--- a/lib/polist/service.rb
+++ b/lib/polist/service.rb
@@ -22,9 +22,9 @@ module Polist
 
     module MiddlewareCaller
       def call
-        unless @__polist_middlewares__called
+        unless @__polist_middlewares__called__
           call_middlewares
-          @__polist_middlewares__called = true
+          @__polist_middlewares__called__ = true
         end
 
         super
@@ -38,7 +38,7 @@ module Polist
     def self.inherited(klass)
       klass.const_set(:Failure, Class.new(klass::Failure))
       klass.prepend(MiddlewareCaller)
-      klass.instance_variable_set(:@__polist_middlewares__, @__polist_middlewares__.dup)
+      klass.instance_variable_set(:@__polist_middlewares__, __polist_middlewares__.dup)
     end
 
     def self.build(*args)


### PR DESCRIPTION
Middlewares should be copied to the child class when inheriting. I faced a problem with `MiddlewareCaller` being prepended into every class in the chain so I had to add one more ugly ivar (`@__polist_middlewares__called`) to make middlewares be called only once.